### PR TITLE
Fix Cannot read property 'parent' of undefined in node

### DIFF
--- a/src/node/self.js
+++ b/src/node/self.js
@@ -17,7 +17,7 @@ var path = require('path');
 // Determine the name by which name the module was required (either 'paper',
 // 'paper-jsdom' or 'paper-jsdom-canvas'), and use this to determine if error
 // exceptions should be thrown or if loading should fail silently.
-var parent = module.parent.parent,
+var parent = module.parent ? module.parent.parent : null,
     requireName = parent && path.basename(path.dirname(parent.filename));
 requireName = /^paper/.test(requireName) ? requireName : 'paper';
 


### PR DESCRIPTION
This happens in webpack generated bundle in node server rendering React application:
```js
TypeError: Cannot read property 'parent' of undefined
    at Object.eval (webpack:///./node_modules/paper/dist/node/self.js?:20:28)
    at eval (webpack:///./node_modules/paper/dist/node/self.js?:62:30)
    at Object../node_modules/paper/dist/node/self.js (/home/bojan/www/climbuddy/client/server/map.bundle.js:34531:1)
    at __webpack_require__ (/home/bojan/www/climbuddy/client/server/map.bundle.js:26:30)
    at Object.eval (webpack:///./node_modules/paper/dist/paper-core.js?:35:16)
    at eval (webpack:///./node_modules/paper/dist/paper-core.js?:14798:3)
    at Object../node_modules/paper/dist/paper-core.js (/home/bojan/www/climbuddy/client/server/map.bundle.js:34553:1)
    at __webpack_require__ (/home/bojan/www/climbuddy/client/server/map.bundle.js:26:30)
    at eval (webpack:///./node_modules/react-paper-bindings/lib/View.js?:15:18)
    at Object../node_modules/react-paper-bindings/lib/View.js (/home/bojan/www/climbuddy/client/server/map.bundle.js:37188:1)
```

### Description


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the ESLint and Prettier rules (`yarn eslint` passes
      and `yarn prettier` has been applied)
